### PR TITLE
chore: Bump ios-core-ui to v18.0.0 minimum

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c8493c83279ec80c992fae0d61b6251b3d95b28a6f07bf79e70d93d5e60701a7",
+  "originHash" : "ce159d66b7137acdbd6f6358f5a8b8032e7e97f4da3c13384c001d0dd45a3979",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -11,21 +11,12 @@
       }
     },
     {
-      "identity" : "cocoalumberjack",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",
-      "state" : {
-        "revision" : "4b8714a7fb84d42393314ce897127b3939885ec3",
-        "version" : "3.8.5"
-      }
-    },
-    {
       "identity" : "ios-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "c3a442b5bd2fb67680aa252638773c4d7d1551ad",
-        "version" : "14.0.0"
+        "revision" : "f9664e0b91a79d86373cafa87f89e0a45deb3128",
+        "version" : "15.0.0"
       }
     },
     {
@@ -33,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core-ui",
       "state" : {
-        "revision" : "9301c5758508f8a65acc1eb83d0c3168d98991e5",
-        "version" : "17.2.0"
+        "revision" : "3c36b8c376dd8779b47a5b03acfbe71ed270282a",
+        "version" : "18.0.0"
       }
     },
     {
@@ -125,15 +116,6 @@
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "17.2.0"))
+        .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "18.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bump to ios-core-ui 18 removes the cocolumberjeck dependency. (explains the removed lines in the project resolved.conf)