### PR TITLE
feat: Dedicated design for one account selected

### DIFF
--- a/Sources/InterAppLogin/Sources/UI/ContinueWithAccountView.swift
+++ b/Sources/InterAppLogin/Sources/UI/ContinueWithAccountView.swift
@@ -53,18 +53,16 @@ private struct OneAccountView: View {
 
 struct ManyAccountView: View {
     let selectedAccounts: [ConnectedAccount]
-    let selectedAccountIds: Set<Int>
 
-    public init(selectedAccounts: [ConnectedAccount], selectedAccountIds: Set<Int>) {
+    public init(selectedAccounts: [ConnectedAccount]) {
         self.selectedAccounts = selectedAccounts
-        self.selectedAccountIds = selectedAccountIds
     }
 
     var body: some View {
         HStack(spacing: IKPadding.mini) {
             ConnectedAccountAvatarStackView(accounts: selectedAccounts)
 
-            Text(InterAppLoginLocalizable.PluralLocalizable.selectedAccountCountLabel(selectedAccountIds.count))
+            Text(InterAppLoginLocalizable.PluralLocalizable.selectedAccountCountLabel(selectedAccounts.count))
                 .frame(maxWidth: .infinity)
                 .lineLimit(1)
 
@@ -123,7 +121,7 @@ public struct ContinueWithAccountView: View {
                         if accounts.count == 1 || selectedAccountIds.count == 1, let selectedAccount = selectedAccounts.first {
                             OneAccountView(account: selectedAccount)
                         } else {
-                            ManyAccountView(selectedAccounts: selectedAccounts, selectedAccountIds: selectedAccountIds)
+                            ManyAccountView(selectedAccounts: selectedAccounts)
                         }
                     }
                     .buttonStyle(.outlined)


### PR DESCRIPTION
Using the login inter-app, if I select one account OR if one account exactly is available, I should see account details.
Screenshot reflect this PR in the specific case aforementioned. Email is where the red rectangle is.

<img width="750" height="1334" alt="IMG_3952" src="https://github.com/user-attachments/assets/7c2627da-0985-473e-acf2-c9510f048943" />

