### PR TITLE
fix: Add background for interapp button

### DIFF
--- a/Sources/InterAppLogin/Sources/Extensions/Color+Extension.swift
+++ b/Sources/InterAppLogin/Sources/Extensions/Color+Extension.swift
@@ -37,4 +37,9 @@ extension Color {
             dark: UIColor.greyOrca
         )
     }
+
+    enum Surface {
+        /// systemBackground
+        static let tertiarySystemBackground: Color = .init(uiColor: .tertiarySystemBackground)
+    }
 }

--- a/Sources/InterAppLogin/Sources/UI/OutlinedButtonStyle.swift
+++ b/Sources/InterAppLogin/Sources/UI/OutlinedButtonStyle.swift
@@ -21,6 +21,21 @@ import Foundation
 import InfomaniakCoreSwiftUI
 import SwiftUI
 
+public extension EnvironmentValues {
+    var outlinedButtonBackgroundColor: Color {
+        get {
+            self[OutlinedButtonBackgroundKey.self]
+        }
+        set {
+            self[OutlinedButtonBackgroundKey.self] = newValue
+        }
+    }
+
+    private struct OutlinedButtonBackgroundKey: EnvironmentKey {
+        static let defaultValue = Color.Surface.tertiarySystemBackground
+    }
+}
+
 extension ButtonStyle where Self == OutlinedButtonStyle {
     static var outlined: OutlinedButtonStyle {
         return OutlinedButtonStyle()
@@ -31,6 +46,7 @@ struct OutlinedButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.ikButtonTheme) private var theme
     @Environment(\.ikButtonLoading) private var isLoading
+    @Environment(\.outlinedButtonBackgroundColor) private var backgroundColor
 
     private var foreground: Color {
         if isEnabled {
@@ -53,6 +69,7 @@ struct OutlinedButtonStyle: ButtonStyle {
             .contentShape(Rectangle())
             .modifier(IKButtonOpacityAnimationModifier(isPressed: configuration.isPressed))
             .allowsHitTesting(!isLoading)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
             .background(
                 RoundedRectangle(cornerRadius: theme.cornerRadius)
                     .stroke(Color.Custom.divider, lineWidth: 0.5)
@@ -66,6 +83,9 @@ struct OutlinedButtonStyle: ButtonStyle {
 
         Button("Hello, World!") {}
             .ikButtonFullWidth(true)
+
+        Button("Hello, World!") {}
+            .environment(\.outlinedButtonBackgroundColor, .red)
     }
     .buttonStyle(.outlined)
 }


### PR DESCRIPTION
| Light | Dark |
| -- | -- |
| <img width="1206" height="2622" alt="Accounts-light" src="https://github.com/user-attachments/assets/f2633b4a-6080-4bd9-8886-2933ceaf0ef3" /> | <img width="1206" height="2622" alt="Accounts" src="https://github.com/user-attachments/assets/7cf46987-ddb9-46b8-a509-78a435502def" /> |
