### PR TITLE
fix: Add padding vertically in the 2FA modal

### DIFF
--- a/Sources/InAppTwoFactorAuthentication/Sources/UI/ConnectionConfirmationView/InformationContentView.swift
+++ b/Sources/InAppTwoFactorAuthentication/Sources/UI/ConnectionConfirmationView/InformationContentView.swift
@@ -52,7 +52,7 @@ struct InformationContentView: View {
             }
             .frame(maxHeight: .infinity, alignment: .bottom)
         }
-        .padding(.horizontal, value: .large)
+        .padding(IKPadding.large)
     }
 }
 

--- a/Sources/InAppTwoFactorAuthentication/Sources/UI/ConnectionConfirmationView/InformationContentView.swift
+++ b/Sources/InAppTwoFactorAuthentication/Sources/UI/ConnectionConfirmationView/InformationContentView.swift
@@ -52,7 +52,7 @@ struct InformationContentView: View {
             }
             .frame(maxHeight: .infinity, alignment: .bottom)
         }
-        .padding(IKPadding.large)
+        .padding(value: .large)
     }
 }
 


### PR DESCRIPTION
Before:
<img width="478" height="527" alt="Capture d’écran 2026-05-08 à 10 40 45" src="https://github.com/user-attachments/assets/6cab55d6-8075-4361-9319-e29d59758436" />


After:
<img width="478" height="524" alt="Capture d’écran 2026-05-08 à 10 39 32 1" src="https://github.com/user-attachments/assets/94aba332-d164-4b1d-9b60-bf5d64759348" />

